### PR TITLE
Null annotation for nvr.lastUpdateAt

### DIFF
--- a/src/Client/DataModels/JsonDataModels.cs
+++ b/src/Client/DataModels/JsonDataModels.cs
@@ -640,7 +640,7 @@ namespace dotMorten.Unifi.Protect.DataModels
         public long Uptime { get; set; }
         public long LastSeen { get; set; }
         public bool IsUpdating { get; set; }
-        public long LastUpdateAt { get; set; }
+        public long? LastUpdateAt { get; set; }
         public bool IsStation { get; set; }
         public bool EnableAutomaticBackups { get; set; }
         public bool EnableStatsReporting { get; set; }


### PR DESCRIPTION
The nvr lastUpdateAt property comes in as null on my environment, updated the model to reflect this. 

```
{
    "nvr": {
        .....
        "uptime": 2003152000,
        "lastSeen": 1630754240591,
        "isUpdating": false,
        "lastUpdateAt": null,
        "isStation": false,
        "enableAutomaticBackups": true,
        "enableStatsReporting": false,
        "isSshEnabled": false,
        "errorCode": null,
        "releaseChannel": "release"
        ....
    }
}
```